### PR TITLE
Remove explicit versions from some dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 # Set up machine requirements to build the repo
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends cmake llvm-9 clang-9 \
-        build-essential python curl git lldb-6.0 liblldb-6.0-dev \
+        build-essential python curl git lldb liblldb-dev \
         libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev \
         libssl-dev libnuma-dev libkrb5-dev zlib1g-dev ninja-build
 


### PR DESCRIPTION
Without this change codespaces fails to open the project. Probably something changed in the base image.

I see from https://github.com/dotnet/roslyn/pull/59074 that codespaces is supposed to work, but it didn't for me without this change.